### PR TITLE
bump to django 4.1

### DIFF
--- a/caster-back/requirements.txt
+++ b/caster-back/requirements.txt
@@ -1,4 +1,4 @@
-django==4.0.2
+django==4.1.3
 uvicorn[standard]==0.17.5
 gunicorn==20.1.0
 psycopg2-binary==2.9.3


### PR DESCRIPTION
Django 4.1 introduces really nice features like an async ORM and more native async views - something which we can use to a great extend in gencaster as our app will run mostly async :)

https://docs.djangoproject.com/en/4.1/releases/4.1/#what-s-new-in-django-4-1 for details if interesed

Tests also run, if CI succeeds we can bump it IMO