### PR TITLE
add sharing of cookies on 127.0.0.1 in local env

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,7 +28,7 @@ dev-server: venv virtualenv
 	. caster-back/venv/bin/activate && (\
 		pip3 install --quiet -r requirements-docs.txt; \
 		cd caster-back; \
-		export SUPERCOLLIDER_HOST=localhost; \
+		export SUPERCOLLIDER_HOST=127.0.0.1; \
 		export SUPERCOLLIDER_PORT=57120; \
 		python manage.py runserver --settings gencaster.settings.test; \
 	)

--- a/caster-back/gencaster/settings/dev.py
+++ b/caster-back/gencaster/settings/dev.py
@@ -2,9 +2,21 @@ from .base import *  # noqa
 
 DEBUG = True
 
-CSRF_TRUSTED_ORIGINS = CSRF_TRUSTED_ORIGINS + [
-    "http://localhost:*",
-    "http://127.0.0.1:*",
+CSRF_TRUSTED_ORIGINS = [
+    "http://localhost:3001",
+    "http://127.0.0.1:3001",
+    "http://localhost:3000",
+    "http://127.0.0.1:3000",
 ]
 
-CORS_ALLOW_ALL_ORIGINS = True
+CORS_ALLOWED_ORIGINS = CSRF_TRUSTED_ORIGINS
+
+CORS_ALLOW_CREDENTIALS = True
+
+SESSION_COOKIE_SECURE = False
+SESSION_COOKIE_DOMAIN = None
+
+# forces us to use 127.0.0.1 instead of localhost
+# b/c otherwise the browser
+# will not share our cookie with the editor/frontend
+SESSION_COOKIE_DOMAIN = "127.0.0.1"

--- a/caster-back/run_tests.sh
+++ b/caster-back/run_tests.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-export SUPERCOLLIDER_HOST=localhost
+export SUPERCOLLIDER_HOST=127.0.0.1
 export SUPERCOLLIDER_PORT=57120
 
 cd "$(dirname "$0")"

--- a/caster-editor/codegen.yml
+++ b/caster-editor/codegen.yml
@@ -1,6 +1,5 @@
 overwrite: true
-# schema: "http://127.0.0.1:8081/graphql"
-schema: 'http://localhost:8081/graphql'
+schema: 'http://127.0.0.1:8081/graphql'
 documents: '../caster-back/*.gql'
 
 generates:

--- a/caster-front/src/components/IndexComponent.vue
+++ b/caster-front/src/components/IndexComponent.vue
@@ -120,7 +120,7 @@ export default {
     initSocket() {
       // eslint-disable-next-line @typescript-eslint/no-this-alias
       const that = this;
-      this.socket = io.connect("ws://localhost:8081");
+      this.socket = io.connect("ws://127.0.0.1:8081");
 
       this.socket.on("connect", () => {
         that.socket.emit("my_event", { data: "I'm connected!" });

--- a/caster-sound/README.md
+++ b/caster-sound/README.md
@@ -14,7 +14,7 @@ If you do not want to use the `docker-compose.yml` file you can build and start 
 
 The container is called `caster-sound`.
 
-One can listen to the stream on and go to [http://localhost:8090](http://localhost:8090).
+One can listen to the stream on and go to [http://127.0.0.1:8090](http://127.0.0.1:8090).
 
 ## Services
 


### PR DESCRIPTION
I noticed that sharing credentials/cookies was not active for local environment, resulting in CORS issues when accesing the editor - I switched this on, but from now on please use `127.0.0.1` all the time instead of `localhost` as we are only able to share our cookies within one domain. This is not so nice but we are tied to security restrictions by the browsers.