### PR TITLE
switch from static serving to node server

### DIFF
--- a/caster-editor/Dockerfile.deploy
+++ b/caster-editor/Dockerfile.deploy
@@ -1,20 +1,15 @@
-FROM node:18-alpine AS builder
+FROM node:18-alpine
 
 WORKDIR /root/caster-editor
 
 COPY package.json .
 COPY yarn.lock .
+COPY nuxt.config.ts .
 
 RUN yarn install --frozen-lockfile
 
-COPY . .
+COPY src/ /root/caster-editor/src/
 
-ARG BACKEND_GRAPHQL_URL
+RUN yarn build
 
-ENV BACKEND_GRAPHQL_URL=${BACKEND_GRAPHQL_URL}
-
-RUN yarn generate
-
-FROM nginx:1.23-alpine
-
-COPY --from=builder /root/caster-editor/.output/public/ /usr/share/nginx/html
+CMD ["node", ".output/server/index.mjs"]

--- a/docker-compose.deploy.dev.yml
+++ b/docker-compose.deploy.dev.yml
@@ -48,12 +48,12 @@ services:
     build:
       context: caster-editor
       dockerfile: Dockerfile.deploy
-      args:
-        - BACKEND_GRAPHQL_URL=https://backend.dev.gencaster.org/graphql
     ports:
-      - 3001:80
+      - 3001:3001
     environment:
-      - NGINX_HOST=0.0.0.0
+      - HOST=0.0.0.0
+      - PORT=3001
+      - BACKEND_GRAPHQL_URL="https://backend.dev.gencaster.org/graphql"
     depends_on:
       - backend
 

--- a/docker-compose.editor.yml
+++ b/docker-compose.editor.yml
@@ -5,8 +5,10 @@ services:
       context: caster-editor
       dockerfile: Dockerfile.deploy
     ports:
-      - 3001:80
+      - 3001:3001
     depends_on:
       - backend
     environment:
-      - NGINX_HOST=0.0.0.0
+      - HOST=0.0.0.0
+      - PORT=3001
+      - BACKEND_GRAPHQL_URL="http://127.0.0.1:8081/graphql"


### PR DESCRIPTION
fixes #69 partially by switching from a static build serving via nginx to a node server serving, allowing for dynamic URL routing like on dev server.

I tried to put the artifact into its own server container (like in the previous version) to make the container as small as possible (for security reasons) but nuxt doesnt work this way.

The bug on `/graph` to `/graph/<uuid>` still persists though.