### PR TITLE
expose graphql web view only in debug environments

### DIFF
--- a/caster-back/gencaster/urls.py
+++ b/caster-back/gencaster/urls.py
@@ -46,7 +46,11 @@ urlpatterns = (
         path("admin/", admin.site.urls),
         path(
             "graphql",
-            CorsAsyncGraphQLView.as_view(schema=schema, subscriptions_enabled=True),
+            CorsAsyncGraphQLView.as_view(
+                schema=schema,
+                subscriptions_enabled=True,
+                graphiql=settings.DEBUG,
+            ),
         ),
     ]
     + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)  # type: ignore


### PR DESCRIPTION
I think its best to show the website https://backend.dev.gencaster.org/graphql only if we are in a debug environment