### PR TITLE
add docker-stop target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ docker-deploy-dev:
 	docker compose $(DOCKER_DEPLOY_DEV) build
 	docker compose $(DOCKER_DEPLOY_DEV) up -d
 
+docker-stop:
+	docker compose $(DOCKER_ALL_FILES) stop
+
 graphql-schema:
 	# assumes that you have docker running and a local setup for caster-editor
 	docker compose -f docker-compose.yml -f docker-compose.local.yml exec backend ./generate_graphql_schema.sh


### PR DESCRIPTION
simply allows us to stop all docker containers via `make docker-stop` which is handy if you closed the terminal where you executed `make docker-local`.
