### PR TITLE
add nginx fallback to index.html

### DIFF
--- a/caster-editor/Dockerfile.deploy
+++ b/caster-editor/Dockerfile.deploy
@@ -20,3 +20,5 @@ RUN npm run build
 FROM nginx:1.23-alpine
 
 COPY --from=builder /root/caster-editor/dist/ /usr/share/nginx/html
+
+COPY nginx.conf /etc/nginx/nginx.conf

--- a/caster-editor/nginx.conf
+++ b/caster-editor/nginx.conf
@@ -1,0 +1,25 @@
+# from https://gist.github.com/vesper8/ec6c079f810afeb19004937b2a153dcc
+
+events {
+  worker_connections  4096;  ## Default: 1024
+}
+
+http {
+    server {
+        include mime.types;
+
+        listen 80;
+
+        root /usr/share/nginx/html/;
+
+        index index.html;
+
+        location / {
+            try_files $uri $uri/ @rewrites;
+        }
+
+        location @rewrites {
+            rewrite ^(.+)$ /index.html last;
+        }
+    }
+}


### PR DESCRIPTION
closes #250 

Implements

https://router.vuejs.org/guide/essentials/history-mode.html#html5-mode

> Here comes a problem, though: Since our app is a single page client side app, without a proper server configuration, the users will get a 404 error if they access https://example.com/user/id directly in their browser. Now that's ugly.
> 
> Not to worry: To fix the issue, all you need to do is add a simple catch-all fallback route to your server. If the URL doesn't match any static assets, it should serve the same index.html page that your app lives in. Beautiful, again!

Basically behaves the same as in dev server with this