### PR TITLE
rerouting to /graphs if uuid is wrong

### DIFF
--- a/caster-editor/src/views/GraphView.vue
+++ b/caster-editor/src/views/GraphView.vue
@@ -1,11 +1,14 @@
 <script lang="ts" setup>
 import { useGraphStore } from "@/stores/GraphStore";
 import { storeToRefs } from "pinia";
-import { computed } from "vue";
-import { useRoute } from "vue-router";
+import { computed, watch } from "vue";
+import { useRoute, useRouter } from "vue-router";
 import Graph from "@/components/Graph.vue";
 
-const { graph, uuid } = storeToRefs(useGraphStore());
+const { graph, uuid, error } = storeToRefs(useGraphStore());
+
+// router
+const router = useRouter();
 
 // get route
 const route = useRoute();
@@ -13,6 +16,12 @@ const routeUUID = computed(() => String(route.params.uuid));
 
 // set uuid
 uuid.value = routeUUID.value;
+
+watch(error, () => {
+  if (error.value?.name === 'CombinedError') {
+    router.push("/graphs");
+  }
+})
 </script>
 
 <template>


### PR DESCRIPTION
Watching `error` param for error `CombinedError` and rerouting then.

Do you think it's the right error (comes from urql) to watch for or should we implement a kind of "invalid uuid" error from the backend?

Seems to work fine though :)