### PR TITLE
change port forwarding for editor

### DIFF
--- a/docker-compose.editor.yml
+++ b/docker-compose.editor.yml
@@ -7,7 +7,7 @@ services:
       args:
         - BACKEND_URL=http://127.0.0.1:8081
     ports:
-      - 3001:3001
+      - 3001:80
     depends_on:
       - backend
     environment:


### PR DESCRIPTION
problem that the editor was not reachable in through the docker container was caused by a wrong port mapping in the compose file