### PR TITLE
improve exit graph dialog

### DIFF
--- a/caster-editor/src/components/DialogExitGraph.vue
+++ b/caster-editor/src/components/DialogExitGraph.vue
@@ -8,8 +8,10 @@
       :show-close="false"
     >
       <span>
-        Are you sure to exit without saving? <br>
-        Some of your changes might get lost.
+        Are you sure to exit the graph?
+        <span v-if="newScriptCellUpdates.size > 0">
+          <br><b>There are unsaved changes in the Node-Editor.</b>
+        </span>
       </span>
       <template #footer>
         <span class="dialog-footer">
@@ -33,6 +35,8 @@
 </template>
 
 <script setup lang="ts">
+import { useInterfaceStore } from "@/stores/InterfaceStore";
+import { storeToRefs } from "pinia";
 import { ref, type Ref } from "vue";
 import { useRouter } from "vue-router";
 
@@ -41,10 +45,18 @@ const emit = defineEmits<{
   (e: "cancel"): void;
 }>();
 
+const interfaceStore = useInterfaceStore();
+const { selectedNodeForEditorUuid, newScriptCellUpdates } =
+  storeToRefs(interfaceStore);
+
 const showDialog: Ref<boolean> = ref(true);
 
 const exitGraph = () => {
   showDialog.value = false;
+
+  selectedNodeForEditorUuid.value = undefined;
+  interfaceStore.resetScriptCellUpdates();
+
   router.push({
     path: "/graph",
   });


### PR DESCRIPTION
Closes #489 

Also displays when closing with unsaved changes

![image](https://github.com/Gencaster/gencaster/assets/8267062/0e4776af-1ab3-429b-a7a5-512c7a6c80a8)

and w/o unsaved changes

<img width="698" alt="image" src="https://github.com/Gencaster/gencaster/assets/8267062/ec99c494-a0e4-4f62-b489-c35079f339a8">
