### PR TITLE
fix audio scriptcell update

### DIFF
--- a/caster-editor/src/components/NodeEditorCell.vue
+++ b/caster-editor/src/components/NodeEditorCell.vue
@@ -98,10 +98,6 @@ const props = defineProps<{
   scriptCell: ScriptCellData;
 }>();
 
-const emit = defineEmits<{
-  (e: "update:scriptCell", scriptCell: ScriptCellData): void;
-}>();
-
 const { newScriptCellUpdates } = storeToRefs(useInterfaceStore());
 
 const scriptCellText = computed<string>({
@@ -111,7 +107,6 @@ const scriptCellText = computed<string>({
   set(value) {
     const newCell = { ...props.scriptCell };
     newCell.cellCode = value;
-    emit("update:scriptCell", newCell);
     return value;
   },
 });

--- a/caster-editor/src/components/ScriptCellCodemirror.vue
+++ b/caster-editor/src/components/ScriptCellCodemirror.vue
@@ -39,10 +39,6 @@ const props = defineProps<{
   uuid: string;
 }>();
 
-const emit = defineEmits<{
-  (e: "update:text", text: string): void;
-}>();
-
 const { newScriptCellUpdates } = storeToRefs(useInterfaceStore());
 
 const domReady: Ref<boolean> = ref(false);
@@ -52,8 +48,6 @@ const scriptText = computed<string>({
     return props.text;
   },
   set(value) {
-    emit("update:text", value);
-
     let update = newScriptCellUpdates.value.get(props.uuid);
 
     if (update) {

--- a/caster-editor/src/components/ScriptCellMarkdown.vue
+++ b/caster-editor/src/components/ScriptCellMarkdown.vue
@@ -30,10 +30,6 @@ const props = defineProps<{
   cellType: CellType.Markdown | CellType.Comment;
 }>();
 
-const emit = defineEmits<{
-  (e: "update:text", text: string): void;
-}>();
-
 // Store
 const { newScriptCellUpdates } = storeToRefs(useInterfaceStore());
 
@@ -46,7 +42,6 @@ const scriptCellText = computed<string>({
     return props.text;
   },
   set(value) {
-    emit("update:text", value);
     let update = newScriptCellUpdates.value.get(props.uuid);
 
     if (update) {


### PR DESCRIPTION
Closes #504 which also did not save any kind of changes on the selected audio file.

I also deleted some `emit`s which we used for the props-update approach (which is ditched for the delta-update-array approach), I think this increased the performance of the app but maybe I am just dreaming. I hope it does not break something, but all manual tests were still running