### PR TITLE
Add autocomplete in editor for custom Python classes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .secrets.env
 data/
 docs/graphs
+caster-back/engineVars.json
 
 # Logs
 logs

--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,11 @@ graphql-schema:
 	cd caster-front && npm run codegen
 	@echo "Sucessfully generated new schema in caster-editor/src/graphql/graphql.ts"
 
+engine-variables-json:
+	docker compose -f docker-compose.yml -f docker-compose.local.yml exec backend ./generate_engine_vars_json.sh
+	cp caster-back/engineVars.json caster-editor/src/
+	@echo "Created new engine variables"
+
 test-backend: venv virtualenv
 	. caster-back/venv/bin/activate && (\
 		cd caster-back; \

--- a/caster-back/generate_engine_vars_json.sh
+++ b/caster-back/generate_engine_vars_json.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+python manage.py get_engine_vars > "engineVars.json"

--- a/caster-back/story_graph/management/commands/get_engine_vars.py
+++ b/caster-back/story_graph/management/commands/get_engine_vars.py
@@ -1,0 +1,103 @@
+import dataclasses
+import enum
+import inspect
+import json
+from typing import Any, Dict, List, Optional
+
+from django.core.management.base import BaseCommand
+
+from story_graph.engine import Engine
+
+
+class CompletionType(str, enum.Enum):
+    CLASS = "class"
+    CONSTANT = "constant"
+    ENUM = "enum"
+    FUNCTION = "function"
+    INTERFACE = "interface"
+    KEYWORD = "keyword"
+    METHOD = "method"
+    NAMESPACE = "namespace"
+    PROPERTY = "property"
+    TEXT = "text"
+    TYPE = "type"
+    VARIABLE = "variable"
+
+
+@dataclasses.dataclass
+class Completion:
+    # from https://codemirror.net/docs/ref/#autocomplete
+    label: str
+    display_label: Optional[str] = None
+    detail: Optional[str] = None
+    info: Optional[str] = None
+    apply: Optional[str] = None
+    type: Optional[CompletionType] = None
+    boost: Optional[int] = None
+    section: Optional[str] = None
+
+
+class Command(BaseCommand):
+    help = "Creates a codemirror JSON with all available variables within a script cell for the editor"
+
+    @staticmethod
+    def empty_method():
+        pass
+
+    async def fake_wait_for_stream_variable(
+        self, name: str, timeout: float = 100.0, update_speed: float = 0.5
+    ):
+        pass
+
+    async def fake_get_stream_variables(self):
+        pass
+
+    def additional_vars(self) -> Dict[str, Any]:
+        # fake some runtime vars via a similar type
+        # like callable/var/etc
+        return {
+            "loop": Command.empty_method,
+            "vars": {},
+            "self": Engine,
+            "get_stream_variables": self.fake_get_stream_variables,
+            "wait_for_stream_variable": self.fake_wait_for_stream_variable,
+        }
+
+    def handle(self, *args, **options):
+        vars = Engine.get_engine_global_vars()["__builtins__"]
+        scoped_vars = {**vars, **self.additional_vars()}
+
+        j: List[Completion] = []
+        for k, v in scoped_vars.items():
+            if callable(v):
+                try:
+                    j.append(
+                        Completion(
+                            label=k,
+                            detail=str(inspect.signature(v)),
+                            type=CompletionType.FUNCTION,
+                            info=inspect.getdoc(v),
+                        )
+                    )
+                except ValueError:
+                    # e.g. int identifies as class but is also
+                    # a callable
+                    j.append(
+                        Completion(
+                            label=k,
+                            type=CompletionType.CLASS,
+                        )
+                    )
+            elif inspect.ismodule(v):
+                j.append(Completion(label=k, detail="", type=CompletionType.NAMESPACE))
+            elif inspect.isclass(v):
+                j.append(
+                    Completion(
+                        label=k, type=CompletionType.CLASS, info=inspect.getdoc(v)
+                    )
+                )
+            else:
+                j.append(Completion(label=k, type=CompletionType.VARIABLE))
+
+        n = [dataclasses.asdict(x) for x in j]
+        print(json.dumps(n, indent=4))

--- a/caster-back/stream/apps.py
+++ b/caster-back/stream/apps.py
@@ -39,7 +39,7 @@ def setup_logging():
         def _loop(self):
             from .models import StreamLog
 
-            print("### START LOGGING THREAD LOOP ###")
+            # print("### START LOGGING THREAD LOOP ###")
             while True:
                 record = self._queue.get()
                 if getattr(record, TO_DB_FLAG, False):

--- a/caster-editor/src/assets/js/completePython.ts
+++ b/caster-editor/src/assets/js/completePython.ts
@@ -1,15 +1,12 @@
 import type { CompletionContext } from "@codemirror/autocomplete";
+import engineVars from "@/engineVars.json";
 
 const completePython = (context: CompletionContext) => {
   const word = context.matchBefore(/\w*/);
   if (word?.from == word?.to && !context.explicit) return null;
   return {
     from: word?.from,
-    options: [
-      { label: "match", type: "keyword" },
-      { label: "hello", type: "variable", info: "(World)" },
-      { label: "magic", type: "text", apply: "⠁⭒*.✩.*⭒⠁", detail: "macro" },
-    ],
+    options: engineVars,
   };
 };
 

--- a/caster-editor/src/assets/js/completePython.ts
+++ b/caster-editor/src/assets/js/completePython.ts
@@ -1,0 +1,16 @@
+import type { CompletionContext } from "@codemirror/autocomplete";
+
+const completePython = (context: CompletionContext) => {
+  const word = context.matchBefore(/\w*/);
+  if (word?.from == word?.to && !context.explicit) return null;
+  return {
+    from: word?.from,
+    options: [
+      { label: "match", type: "keyword" },
+      { label: "hello", type: "variable", info: "(World)" },
+      { label: "magic", type: "text", apply: "⠁⭒*.✩.*⭒⠁", detail: "macro" },
+    ],
+  };
+};
+
+export default completePython;

--- a/caster-editor/src/assets/js/completeSC.ts
+++ b/caster-editor/src/assets/js/completeSC.ts
@@ -1,0 +1,16 @@
+import type { CompletionContext } from "@codemirror/autocomplete";
+
+const completeSC = (context: CompletionContext) => {
+  const word = context.matchBefore(/\w*/);
+  if (word?.from == word?.to && !context.explicit) return null;
+  return {
+    from: word?.from,
+    options: [
+      { label: "match", type: "keyword" },
+      { label: "hello", type: "variable", info: "(World)" },
+      { label: "magic", type: "text", apply: "⠁⭒*.✩.*⭒⠁", detail: "macro" },
+    ],
+  };
+};
+
+export default completeSC;

--- a/caster-editor/src/components/Menu.vue
+++ b/caster-editor/src/components/Menu.vue
@@ -65,7 +65,7 @@ const { tab } = storeToRefs(useInterfaceStore());
 const showExitGraphDialog: Ref<boolean> = ref(false);
 
 const goToDocs = () => {
-  window.open("https://docs.gencaster.org/", "_blank");
+  window.open("https://docs.gencaster.org/editor", "_blank");
 };
 </script>
 

--- a/caster-editor/src/components/ScriptCellCodemirror.vue
+++ b/caster-editor/src/components/ScriptCellCodemirror.vue
@@ -1,37 +1,17 @@
-<template>
-  <div class="block block-codemirror">
-    <div
-      :class="{
-        'editor-supercollider': cellType === CellType.Supercollider,
-        'editor-python': cellType === CellType.Python,
-      }"
-    >
-      <!-- :disable="dragging" -->
-      <Codemirror
-        v-model="scriptText"
-        placeholder="Code goes here..."
-        :autofocus="false"
-        :indent-with-tab="true"
-        :tab-size="2"
-        :extensions="[python()]"
-        @ready="
-          () => {
-            domReady = true;
-          }
-        "
-      />
-    </div>
-  </div>
-</template>
-
 <script lang="ts" setup>
-import { Codemirror } from "vue-codemirror";
-import { python } from "@codemirror/lang-python";
 import { computed, ref } from "vue";
 import type { Ref } from "vue";
 import { storeToRefs } from "pinia";
 import { CellType } from "@/graphql";
 import { useInterfaceStore } from "@/stores/InterfaceStore";
+
+// Codemirror
+import { Codemirror } from "vue-codemirror";
+import { python, pythonLanguage } from "@codemirror/lang-python";
+
+// autocomplete
+import completePython from "@/assets/js/completePython";
+import completeSC from "@/assets/js/completeSC";
 
 const props = defineProps<{
   text: string;
@@ -61,4 +41,49 @@ const scriptText = computed<string>({
     return value;
   },
 });
+
+// autocomplete
+const pythonDocCompletions = pythonLanguage.data.of({
+  autocomplete: completePython,
+});
+
+// TODO: add scDocCompletions. Not working like this
+const scDocCompletions = pythonLanguage.data.of({
+  autocomplete: completeSC,
+});
+
+// extensions
+const extensions = computed(() => {
+  if (props.cellType === CellType.Python) {
+    return [python(), pythonDocCompletions];
+  } else {
+    return [];
+  }
+});
 </script>
+
+<template>
+  <div class="block block-codemirror">
+    <div
+      :class="{
+        'editor-supercollider': cellType === CellType.Supercollider,
+        'editor-python': cellType === CellType.Python,
+      }"
+    >
+      <!-- :disable="dragging" -->
+      <Codemirror
+        v-model="scriptText"
+        placeholder="Code goes here..."
+        :autofocus="false"
+        :indent-with-tab="true"
+        :tab-size="2"
+        :extensions="extensions"
+        @ready="
+          () => {
+            domReady = true;
+          }
+        "
+      />
+    </div>
+  </div>
+</template>

--- a/caster-editor/src/engineVars.json
+++ b/caster-editor/src/engineVars.json
@@ -1,0 +1,172 @@
+[
+  {
+    "label": "asyncio",
+    "display_label": null,
+    "detail": "",
+    "info": null,
+    "apply": null,
+    "type": "namespace",
+    "boost": null,
+    "section": null
+  },
+  {
+    "label": "int",
+    "display_label": null,
+    "detail": null,
+    "info": null,
+    "apply": null,
+    "type": "class",
+    "boost": null,
+    "section": null
+  },
+  {
+    "label": "float",
+    "display_label": null,
+    "detail": "(x=0, /)",
+    "info": "Convert a string or number to a floating point number, if possible.",
+    "apply": null,
+    "type": "function",
+    "boost": null,
+    "section": null
+  },
+  {
+    "label": "print",
+    "display_label": null,
+    "detail": null,
+    "info": null,
+    "apply": null,
+    "type": "class",
+    "boost": null,
+    "section": null
+  },
+  {
+    "label": "time",
+    "display_label": null,
+    "detail": "",
+    "info": null,
+    "apply": null,
+    "type": "namespace",
+    "boost": null,
+    "section": null
+  },
+  {
+    "label": "datetime",
+    "display_label": null,
+    "detail": null,
+    "info": null,
+    "apply": null,
+    "type": "class",
+    "boost": null,
+    "section": null
+  },
+  {
+    "label": "timedelta",
+    "display_label": null,
+    "detail": null,
+    "info": null,
+    "apply": null,
+    "type": "class",
+    "boost": null,
+    "section": null
+  },
+  {
+    "label": "Text",
+    "display_label": null,
+    "detail": "(*, text: str) -> None",
+    "info": "Displays plain text.",
+    "apply": null,
+    "type": "function",
+    "boost": null,
+    "section": null
+  },
+  {
+    "label": "Dialog",
+    "display_label": null,
+    "detail": "(*, title: str, content: <strawberry.type.StrawberryList object at 0x7fc52ff9c850>, buttons: List[stream.frontend_types.Button]) -> None",
+    "info": "Triggers a popup on the frontend of the listener.",
+    "apply": null,
+    "type": "function",
+    "boost": null,
+    "section": null
+  },
+  {
+    "label": "Button",
+    "display_label": null,
+    "detail": "(*, text: str, value: str, key: str = 'button', button_type: stream.frontend_types.ButtonType = <ButtonType.DEFAULT: 'default'>, callback_actions: List[stream.frontend_types.CallbackAction] = <factory>) -> None",
+    "info": "A button which can also trigger a set of functionality.",
+    "apply": null,
+    "type": "function",
+    "boost": null,
+    "section": null
+  },
+  {
+    "label": "Checkbox",
+    "display_label": null,
+    "detail": "(*, key: str, label: str, checked: bool = False, callback_actions: List[stream.frontend_types.CallbackAction] = <factory>) -> None",
+    "info": "A classic ``<checkbox>`` whose state (``true``/``false``) will be\nsaved **as a string** under ``key`` in a :class:`~stream.models.StreamVariable`.",
+    "apply": null,
+    "type": "function",
+    "boost": null,
+    "section": null
+  },
+  {
+    "label": "Input",
+    "display_label": null,
+    "detail": "(*, key: str, label: str = 'input', placeholder: str = 'Please input') -> None",
+    "info": "A classic ``<inptut>`` which will save its content\nunder the ``key`` as a :class:`~stream.models.StreamVariable`.",
+    "apply": null,
+    "type": "function",
+    "boost": null,
+    "section": null
+  },
+  {
+    "label": "loop",
+    "display_label": null,
+    "detail": "()",
+    "info": null,
+    "apply": null,
+    "type": "function",
+    "boost": null,
+    "section": null
+  },
+  {
+    "label": "vars",
+    "display_label": null,
+    "detail": null,
+    "info": null,
+    "apply": null,
+    "type": "variable",
+    "boost": null,
+    "section": null
+  },
+  {
+    "label": "self",
+    "display_label": null,
+    "detail": "(graph: story_graph.models.Graph, stream: stream.models.Stream, raise_exceptions: bool = False) -> None",
+    "info": "An engine executes a :class:`~story_graph.models.Graph` for a given\n:class:`~stream.models.StreamPoint`.\nExecuting means to iterate over the :class:`~story_graph.models.Node`\nand executing each :class:`~story_graph.models.ScriptCell` within such a node.\n\nThe engine runs in an async manner so it is possible to do awaits without\nblocking the server, which means execution is halted until a specific\ncondition is met.",
+    "apply": null,
+    "type": "function",
+    "boost": null,
+    "section": null
+  },
+  {
+    "label": "get_stream_variables",
+    "display_label": null,
+    "detail": "()",
+    "info": null,
+    "apply": null,
+    "type": "function",
+    "boost": null,
+    "section": null
+  },
+  {
+    "label": "wait_for_stream_variable",
+    "display_label": null,
+    "detail": "(name: str, timeout: float = 100.0, update_speed: float = 0.5)",
+    "info": null,
+    "apply": null,
+    "type": "function",
+    "boost": null,
+    "section": null
+  }
+]

--- a/caster-editor/tsconfig.app.json
+++ b/caster-editor/tsconfig.app.json
@@ -1,6 +1,6 @@
 {
   "extends": "@vue/tsconfig/tsconfig.web.json",
-  "include": ["env.d.ts", "src/**/*", "src/**/*.vue", "assets/**/**/*"],
+  "include": ["env.d.ts", "src/**/*", "src/**/*.vue", "assets/**/**/*", "src/*.json"],
   "exclude": ["src/**/__tests__/*"],
   "compilerOptions": {
     "composite": true,


### PR DESCRIPTION
Closes #482

In case the variables for the python engine gets updated a new JSON can be generated via

```shell
make engine-variables-json
```

which is also documented.

edit: also changed the docs link, see https://github.com/Gencaster/gencaster/pull/539/commits/4aa556027fa944cc95a2d7286b2f3ef7ae36eae3