### PR TITLE
564 add meta editing to the editor

### DIFF
--- a/caster-back/operations.gql
+++ b/caster-back/operations.gql
@@ -208,6 +208,25 @@ subscription node($uuid: UUID!) {
   }
 }
 
+fragment GraphMetaData on Graph {
+  uuid
+  templateName
+  startText
+  slugName
+  name
+  endText
+  displayName
+  aboutText
+  streamAssignmentPolicy
+  publicVisible
+}
+
+query GetGraph($graphUuid:ID!) {
+	graph(pk: $graphUuid) {
+    ...GraphMetaData
+  }
+}
+
 mutation CreateGraph($graphInput: AddGraphInput!) {
   addGraph(graphInput: $graphInput) {
     name
@@ -217,6 +236,15 @@ mutation CreateGraph($graphInput: AddGraphInput!) {
       uuid
       isEntryNode
     }
+  }
+}
+
+mutation UpdateGraph($graphUuid:UUID!, $graphUpdate: UpdateGraphInput!) {
+  updateGraph(
+    graphInput: $graphUpdate
+    graphUuid: $graphUuid
+  ) {
+    uuid
   }
 }
 

--- a/caster-back/schema.gql
+++ b/caster-back/schema.gql
@@ -47,7 +47,7 @@ input AddGraphInput {
   publicVisible: Boolean
 
   """Manages the stream assignment for this graph"""
-  streamAssignmentPolicy: String
+  streamAssignmentPolicy: StreamAssignmentPolicy
 
   """
   Allows to switch to a different template in the frontend with different connection flows or UI
@@ -360,6 +360,14 @@ type Graph {
   """
   templateName: GraphDetailTemplate!
 
+  """Manages the stream assignment for this graph"""
+  streamAssignmentPolicy: StreamAssignmentPolicy!
+
+  """
+  If the graph is not public it will not be listed in the frontend, yet it is still accessible via URL
+  """
+  publicVisible: Boolean!
+
   """
   Text about the graph which will be displayed at the start of a stream - only if this is set
   """
@@ -492,6 +500,7 @@ type Mutation {
   """Deletes a given :class:`~story_graph.models.ScriptCell`."""
   deleteScriptCell(scriptCellUuid: UUID!): Void
   addGraph(graphInput: AddGraphInput!): Graph!
+  updateGraph(graphInput: UpdateGraphInput!, graphUuid: UUID!): Graph!
   addAudioFile(newAudioFile: AddAudioFile!): AudioFileUploadResponse!
   createUpdateStreamVariable(streamVariables: [StreamVariableInput!]!): [StreamVariable!]!
   createNodeDoor(nodeDoorInput: NodeDoorInputCreate!, nodeUuid: UUID!): NodeDoor!
@@ -758,6 +767,13 @@ type Stream {
   streamPoint: StreamPoint!
 }
 
+"""An enumeration."""
+enum StreamAssignmentPolicy {
+  ONE_GRAPH_ONE_STREAM
+  ONE_USER_ONE_STREAM
+  DEACTIVATE
+}
+
 type StreamInfo {
   stream: Stream!
   streamInstruction: StreamInstruction
@@ -928,6 +944,53 @@ input UUIDFilterLookup {
 input UpdateAudioFile {
   description: String
   name: String
+}
+
+"""
+A collection of :class:`~Node` and :class:`~Edge`.
+This can be considered a score as well as a program as it
+has an entry point as a :class:`~Node` and can jump to any
+other :class:`~Node`, also allowing for recursive loops/cycles.
+
+Each node can be considered a little program on its own which can consist
+of multiple :class:`~ScriptCell` which can be coded in a variety of
+languages which can control the frontend and the audio (by e.g. speaking
+on the stream) or setting a background music.
+
+The story graph is a core concept and can be edited with a native editor.
+"""
+input UpdateGraphInput {
+  """Name of the graph"""
+  name: String
+
+  """Will be used as a display name in the frontend"""
+  displayName: String
+
+  """
+  Text about the graph which will be displayed at the start of a stream - only if this is set
+  """
+  startText: String
+
+  """
+  Text about the graph which can be accessed during a stream - only if this is set
+  """
+  aboutText: String
+
+  """Text which will be displayed at the end of a stream"""
+  endText: String
+
+  """
+  If the graph is not public it will not be listed in the frontend, yet it is still accessible via URL
+  """
+  publicVisible: Boolean
+
+  """Manages the stream assignment for this graph"""
+  streamAssignmentPolicy: StreamAssignmentPolicy
+
+  """
+  Allows to switch to a different template in the frontend with different connection flows or UI
+  """
+  templateName: GraphDetailTemplate
 }
 
 scalar Upload

--- a/caster-back/story_graph/types.py
+++ b/caster-back/story_graph/types.py
@@ -22,6 +22,7 @@ CellType = strawberry.enum(models.CellType)  # type: ignore
 PlaybackType = strawberry.enum(models.AudioCell.PlaybackChoices)  # type: ignore
 TemplateType = strawberry.enum(models.Graph.GraphDetailTemplate)  # type: ignore
 NodeDoorType = strawberry.enum(models.NodeDoor.DoorType)  # type: ignore
+StreamAssignmentPolicy = strawberry.enum(models.Graph.StreamAssignmentPolicy)  # type: ignore
 
 
 def create_python_highlight_string(e: SyntaxError) -> str:
@@ -85,6 +86,8 @@ class Graph:
     display_name: auto
     slug_name: auto
     template_name: TemplateType
+    stream_assignment_policy: StreamAssignmentPolicy
+    public_visible: auto
     start_text: auto
     about_text: auto
     end_text: auto
@@ -93,6 +96,31 @@ class Graph:
     @strawberry.django.field
     def edges(self) -> List["Edge"]:
         return models.Edge.objects.filter(out_node_door__node__graph=self)  # type: ignore
+
+
+@strawberry.django.input(models.Graph)
+class AddGraphInput:
+    name: auto
+    display_name: auto
+    slug_name: auto
+    start_text: auto
+    about_text: auto
+    end_text: auto
+    public_visible: auto
+    stream_assignment_policy: StreamAssignmentPolicy
+    template_name: TemplateType
+
+
+@strawberry.django.input(model=models.Graph, partial=True)
+class UpdateGraphInput:
+    name: auto
+    display_name: auto
+    start_text: auto
+    about_text: auto
+    end_text: auto
+    public_visible: auto
+    stream_assignment_policy: StreamAssignmentPolicy
+    template_name: TemplateType
 
 
 @strawberry.django.type(models.Node)
@@ -210,16 +238,3 @@ class ScriptCellInputUpdate:
     cell_code: Optional[str]
     cell_order: Optional[int]
     audio_cell: Optional[AudioCellInput]
-
-
-@strawberry.django.input(models.Graph)
-class AddGraphInput:
-    name: auto
-    display_name: auto
-    slug_name: auto
-    start_text: auto
-    about_text: auto
-    end_text: auto
-    public_visible: auto
-    stream_assignment_policy: auto
-    template_name: TemplateType

--- a/caster-editor/src/assets/scss/_elementplus.scss
+++ b/caster-editor/src/assets/scss/_elementplus.scss
@@ -142,6 +142,19 @@
   border: none;
 }
 
+.el-loading-mask {
+  // background-color: $white-transparent;
+  color: #{$black};
+}
+
+.el-loading-spinner .el-loading-text {
+  color: #{$black};
+}
+
+.el-loading-spinner .path {
+  stroke: #{$black};
+}
+
 /* OLD */
 
 .messages-editor {

--- a/caster-editor/src/components/MenuTabEdit.vue
+++ b/caster-editor/src/components/MenuTabEdit.vue
@@ -54,8 +54,9 @@ const removeSelection = async () => {
     });
     if (error) {
       ElMessage.error(`Could not delete edge ${edgeUuid}: ${error.message}`);
+    } else {
+      ElMessage.info(`Deleted edge ${edgeUuid}`);
     }
-    ElMessage.info(`Deleted edge ${edgeUuid}`);
   });
 
   selectedNodeUUIDs.value.forEach(async (nodeUuid) => {
@@ -64,8 +65,9 @@ const removeSelection = async () => {
     });
     if (error) {
       ElMessage.error(`Could not delete node ${nodeUuid}: ${error.message}`);
+    } else {
+      ElMessage.info(`Deleted node ${nodeUuid}`);
     }
-    ElMessage.info(`Deleted node ${nodeUuid}`);
   });
 };
 </script>

--- a/caster-editor/src/components/MenuTabHeader.vue
+++ b/caster-editor/src/components/MenuTabHeader.vue
@@ -1,3 +1,10 @@
+<script setup lang="ts">
+import { useInterfaceStore, Tab } from "@/stores/InterfaceStore";
+import { storeToRefs } from "pinia";
+
+const { tab } = storeToRefs(useInterfaceStore());
+</script>
+
 <template>
   <div class="menu-items left">
     <ElRadioGroup v-model="tab">
@@ -7,13 +14,9 @@
       <ElRadioButton :label="Tab.Play">
         Listen
       </ElRadioButton>
+      <ElRadioButton :label="Tab.Meta">
+        Meta
+      </ElRadioButton>
     </ElRadioGroup>
   </div>
 </template>
-
-<script setup lang="ts">
-import { useInterfaceStore, Tab } from "@/stores/InterfaceStore";
-import { storeToRefs } from "pinia";
-
-const { tab } = storeToRefs(useInterfaceStore());
-</script>

--- a/caster-editor/src/components/Meta.vue
+++ b/caster-editor/src/components/Meta.vue
@@ -11,7 +11,7 @@ import {
   ElSwitch,
   ElMessage,
 } from "element-plus";
-import { ref, type Ref, watch } from "vue";
+import { ref, type Ref, watch, computed } from "vue";
 import "@toast-ui/editor/dist/toastui-editor.css"; // Editor's Style
 import Wysiwyg from "@/components/Wysiwyg.vue";
 import {
@@ -39,6 +39,17 @@ watch(error, (errorMsg) => {
 
 watch(data, (newData) => {
   formData.value = newData?.graph ?? {};
+  saveOriginalData();
+});
+
+const originalData: Ref<UpdateGraphInput> = ref({});
+
+const saveOriginalData = () => {
+  originalData.value = { ...formData.value };
+};
+
+const compareData = computed(() => {
+  return JSON.stringify(formData.value) === JSON.stringify(originalData.value);
 });
 
 const formData: Ref<UpdateGraphInput> = ref({});
@@ -77,6 +88,7 @@ const onSubmit = async () => {
   });
   if (error) {
     ElMessage.error(`Failed to update the meta-data: ${error.message}`);
+  } else {
   }
   mutationRuns.value = false;
   executeQuery();
@@ -146,19 +158,7 @@ const onSubmit = async () => {
         </ElFormItem>
       </ElCol>
 
-      <ElCol :span="24">
-        <ElFormItem
-          label="Listed publicly"
-          prop="publicVisible"
-        >
-          <ElSwitch
-            v-if="formData.publicVisible != undefined"
-            v-model="formData.publicVisible"
-          />
-        </ElFormItem>
-      </ElCol>
-
-      <ElCol :span="24">
+      <ElCol :span="12">
         <ElFormItem label="Intro Text">
           <ElInput
             v-model="formData.startText"
@@ -166,6 +166,18 @@ const onSubmit = async () => {
             show-word-limit
             type="text"
             maxlength="60"
+          />
+        </ElFormItem>
+      </ElCol>
+
+      <ElCol :span="12">
+        <ElFormItem
+          label="Listed publicly"
+          prop="publicVisible"
+        >
+          <ElSwitch
+            v-if="formData.publicVisible != undefined"
+            v-model="formData.publicVisible"
           />
         </ElFormItem>
       </ElCol>
@@ -196,11 +208,13 @@ const onSubmit = async () => {
       <ElFormItem class="save-buttons">
         <ElButton
           type="primary"
+          :disabled="compareData"
           @click="onSubmit"
         >
           Save
         </ElButton>
         <ElButton
+          :disabled="compareData"
           @click="
             () => {
               executeQuery();

--- a/caster-editor/src/components/Meta.vue
+++ b/caster-editor/src/components/Meta.vue
@@ -1,0 +1,237 @@
+<!-- eslint-disable vue/no-v-model-argument -->
+<script lang="ts" setup>
+import {
+  ElButton,
+  ElInput,
+  ElSelect,
+  ElOption,
+  ElForm,
+  ElFormItem,
+  ElCol,
+} from "element-plus";
+import {
+  reactive,
+  ref,
+  onMounted,
+  onDeactivated,
+  type Ref,
+  computed,
+} from "vue";
+import type { GraphSubscription, Graph } from "@/graphql";
+import "@toast-ui/editor/dist/toastui-editor.css"; // Editor's Style
+import type { EditorOptions, Editor as EditorType } from "@toast-ui/editor";
+import Editor from "@toast-ui/editor";
+import Wysiwyg from "@/components/Wysiwyg.vue";
+import { useInterfaceStore, Tab } from "@/stores/InterfaceStore";
+
+import { storeToRefs } from "pinia";
+const { tab } = storeToRefs(useInterfaceStore());
+
+// props
+// const props = defineProps<{
+//   graph: GraphSubscription["graph"];
+// }>();
+
+const props = defineProps<{
+  graph: Graph;
+  showDebug?: boolean;
+}>();
+
+// TODO: Import from graphql
+const streamAssignmentOptions = [
+  {
+    value: "one_graph_one_stream",
+    label: "Each graph has only one stream",
+  },
+  {
+    value: "one_user_one_stream",
+    label: "Each user gets its own stream",
+  },
+  {
+    value: "deactivate",
+    label: "No stream assignment",
+  },
+];
+
+const metaForm = reactive({
+  projectName: "",
+  displayName: "",
+  slug: "",
+  streamAssignment: "",
+  introText: "",
+  aboutText: "",
+  endText: "",
+});
+
+// cloning needs plugin, so just being redundant for now
+const metaFormOriginal = reactive({
+  projectName: "",
+  displayName: "",
+  slug: "",
+  streamAssignment: "",
+  introText: "",
+  aboutText: "",
+  endText: "",
+});
+
+const saveButtonActive = computed(() => {
+  if (JSON.stringify(metaForm) !== JSON.stringify(metaFormOriginal)) {
+    return true;
+  } else {
+    return false;
+  }
+});
+
+const onSubmit = () => {
+  console.log("Submitted");
+  console.log(metaForm);
+};
+
+const onCancel = () => {
+  // tab.value = Tab.Edit;
+  console.log(JSON.stringify(metaForm));
+};
+
+const populateData = () => {
+  // form
+  metaForm.projectName = props.graph.name;
+  metaForm.displayName = props.graph.displayName;
+  metaForm.slug = props.graph.slugName;
+  metaForm.streamAssignment = "one_graph_one_stream";
+  metaForm.introText = props.graph.startText;
+  metaForm.aboutText = props.graph.aboutText;
+  metaForm.endText = props.graph.endText;
+
+  // original data
+  metaFormOriginal.projectName = props.graph.name;
+  metaFormOriginal.displayName = props.graph.displayName;
+  metaFormOriginal.slug = props.graph.slugName;
+  metaFormOriginal.streamAssignment = "one_graph_one_stream";
+  metaFormOriginal.introText = props.graph.startText;
+  metaFormOriginal.aboutText = props.graph.aboutText;
+  metaFormOriginal.endText = props.graph.endText;
+};
+
+populateData();
+</script>
+
+<template>
+  <div class="meta-wrapper">
+    <ElForm
+      :model="metaForm"
+      label-width="150px"
+      label-position="top"
+      inline
+    >
+      <ElCol :span="12">
+        <ElFormItem label="Project name">
+          <ElInput
+            v-model="metaForm.projectName"
+            placeholder="Project Name"
+          />
+        </ElFormItem>
+      </ElCol>
+
+      <ElCol :span="12">
+        <ElFormItem label="Display name">
+          <ElInput
+            v-model="metaForm.displayName"
+            placeholder="Display Name"
+          />
+        </ElFormItem>
+      </ElCol>
+
+      <ElCol :span="12">
+        <ElFormItem label="Slug">
+          <ElInput
+            v-model="metaForm.slug"
+            placeholder="Slug"
+            disabled
+          />
+        </ElFormItem>
+      </ElCol>
+
+      <ElCol :span="12">
+        <ElFormItem label="Stream assignment">
+          <ElSelect
+            v-model="metaForm.streamAssignment"
+            placeholder="Select"
+          >
+            <ElOption
+              v-for="item in streamAssignmentOptions"
+              :key="item.value"
+              :label="item.label"
+              :value="item.value"
+            />
+          </ElSelect>
+        </ElFormItem>
+      </ElCol>
+
+      <ElCol :span="24">
+        <ElFormItem label="Intro Text">
+          <Wysiwyg :text="metaForm.introText" />
+        </ElFormItem>
+      </ElCol>
+
+      <ElCol :span="24">
+        <ElFormItem label="About Text">
+          <Wysiwyg :text="metaForm.aboutText" />
+        </ElFormItem>
+      </ElCol>
+      <ElCol :span="24">
+        <ElFormItem label="End Text">
+          <Wysiwyg :text="metaForm.endText" />
+        </ElFormItem>
+      </ElCol>
+
+      <ElFormItem class="save-buttons">
+        <ElButton
+          type="primary"
+          :disabled="!saveButtonActive"
+          @click="onSubmit"
+        >
+          Save
+        </ElButton>
+        <ElButton @click="onCancel">
+          Cancel
+        </ElButton>
+      </ElFormItem>
+    </ElForm>
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import "@/assets/scss/variables.module.scss";
+
+.meta-wrapper {
+  position: absolute;
+  top: 64px;
+  left: 0;
+  width: 100%;
+  height: calc(100vh - 64px);
+  background-color: $white;
+  overflow-y: scroll;
+  padding: $spacingM;
+  padding-top: $spacingM;
+  // background-color: red;
+
+  .el-form {
+    max-width: 740px;
+    width: 100%;
+    margin: 0 auto;
+    // background-color: yellow;
+
+    :deep(.el-select) {
+      width: 100%;
+    }
+  }
+
+  .save-buttons {
+    position: absolute;
+    top: calc(64px + #{$spacingM});
+    top: #{$spacingM};
+    right: $spacingM;
+    margin: 0;
+  }
+}
+</style>

--- a/caster-editor/src/components/Meta.vue
+++ b/caster-editor/src/components/Meta.vue
@@ -76,7 +76,8 @@ const populateData = () => {
   metaForm.value.projectName = props.graph.name;
   metaForm.value.displayName = props.graph.displayName;
   metaForm.value.slug = props.graph.slugName;
-  metaForm.value.streamAssignment = "one_graph_one_stream";
+  //TODO: streamAssignment
+  metaForm.value.streamAssignment = "missing graph ql";
   metaForm.value.startText = props.graph.startText;
   metaForm.value.aboutText = props.graph.aboutText;
   metaForm.value.endText = props.graph.endText;
@@ -85,7 +86,7 @@ const populateData = () => {
   metaFormOriginal.value.projectName = props.graph.name;
   metaFormOriginal.value.displayName = props.graph.displayName;
   metaFormOriginal.value.slug = props.graph.slugName;
-  metaFormOriginal.value.streamAssignment = "one_graph_one_stream";
+  metaFormOriginal.value.streamAssignment = "missing graph ql";
   metaFormOriginal.value.startText = props.graph.startText;
   metaFormOriginal.value.aboutText = props.graph.aboutText;
   metaFormOriginal.value.endText = props.graph.endText;

--- a/caster-editor/src/components/Wysiwyg.vue
+++ b/caster-editor/src/components/Wysiwyg.vue
@@ -1,0 +1,81 @@
+<!-- eslint-disable vue/no-v-model-argument -->
+<script lang="ts" setup>
+import { reactive, ref, onMounted, onDeactivated, type Ref } from "vue";
+
+import "@toast-ui/editor/dist/toastui-editor.css"; // Editor's Style
+import type { EditorOptions, Editor as EditorType } from "@toast-ui/editor";
+import Editor from "@toast-ui/editor";
+
+// props
+const props = defineProps<{
+  text: string;
+}>();
+
+// Editor Settings
+const editorDom: Ref<HTMLElement | undefined> = ref();
+const editor: Ref<EditorType | undefined> = ref();
+
+onMounted(() => {
+  const options: EditorOptions = {
+    el: editorDom.value as HTMLElement,
+    height: "auto",
+    minHeight: "0px",
+    initialEditType: "wysiwyg",
+    usageStatistics: false,
+    initialValue: props.text,
+    previewStyle: "tab",
+    // https://github.com/nhn/tui.editor/blob/master/docs/en/toolbar.md
+    toolbarItems: [
+      ["heading", "bold", "italic", "strike"],
+      ["hr"],
+      ["ul", "ol"],
+      ["table", "image", "link"],
+    ],
+    hideModeSwitch: true,
+    autofocus: false,
+  };
+
+  console.log(props.text);
+
+  editor.value = new Editor(options);
+
+  // add events
+  // editor.value.on("change", () => {
+  //   scriptCellText.value = editor.value?.getMarkdown() || "";
+  // });
+});
+
+onDeactivated(() => {
+  if (editor.value) {
+    editor.value.destroy();
+  }
+});
+</script>
+
+<template>
+  <div class="wysiwyg-wrapper">
+    <div
+      ref="editorDom"
+      class="editor"
+    />
+  </div>
+</template>
+
+<style lang="scss" scoped>
+@import "@/assets/scss/variables.module.scss";
+
+.wysiwyg-wrapper {
+  width: 100%;
+  margin: 0 !important;
+}
+
+.editor {
+  position: relative;
+  display: block;
+  width: 100%;
+
+  :deep(.toastui-editor-defaultUI-toolbar) {
+    background-color: $grey-light !important;
+  }
+}
+</style>

--- a/caster-editor/src/components/Wysiwyg.vue
+++ b/caster-editor/src/components/Wysiwyg.vue
@@ -35,15 +35,17 @@ onMounted(() => {
     autofocus: false,
   };
 
-  console.log(props.text);
-
   editor.value = new Editor(options);
 
   // add events
-  // editor.value.on("change", () => {
-  //   scriptCellText.value = editor.value?.getMarkdown() || "";
-  // });
+  editor.value.on("change", () => {
+    emit("updateText", editor.value?.getMarkdown() || "sampletext");
+  });
 });
+
+const emit = defineEmits<{
+  (e: "updateText", text: string): void;
+}>();
 
 onDeactivated(() => {
   if (editor.value) {

--- a/caster-editor/src/graphql.ts
+++ b/caster-editor/src/graphql.ts
@@ -1251,6 +1251,11 @@ export type GraphSubscription = {
         node: { uuid: any };
       }>;
     }>;
+    aboutText: string;
+    displayName: string;
+    endText: string;
+    startText: string;
+    templateName: GraphDetailTemplate;
   };
 };
 
@@ -1882,6 +1887,11 @@ export const GraphDocument = gql`
       name
       slugName
       uuid
+      aboutText
+      displayName
+      endText
+      startText
+      templateName
       edges {
         uuid
         inNodeDoor {

--- a/caster-editor/src/stores/InterfaceStore.ts
+++ b/caster-editor/src/stores/InterfaceStore.ts
@@ -1,5 +1,5 @@
 import { defineStore } from "pinia";
-import { type Ref, ref, computed } from "vue";
+import { type Ref, ref, computed, watch } from "vue";
 import {
   type NodeSubscription,
   type ScriptCellInputUpdate,
@@ -31,6 +31,12 @@ export const useInterfaceStore = defineStore("interface", () => {
   const vueFlowRef: Ref<CustomGraph | undefined> = ref(undefined);
 
   const tab: Ref<Tab> = ref(Tab.Edit);
+
+  watch(tab, (newValue, oldValue) => {
+    if (oldValue == Tab.Edit && newValue == Tab.Meta) {
+      showNodeEditor.value = false;
+    }
+  });
 
   // this acts as a clutch between our local changes and the
   // updates from the server.

--- a/caster-editor/src/stores/InterfaceStore.ts
+++ b/caster-editor/src/stores/InterfaceStore.ts
@@ -14,6 +14,7 @@ import { ElMessage } from "element-plus";
 export enum Tab {
   Edit = "Edit",
   Play = "Play",
+  Meta = "Meta",
 }
 
 // some hack to avoid

--- a/caster-editor/src/views/GraphDetailView.vue
+++ b/caster-editor/src/views/GraphDetailView.vue
@@ -43,7 +43,7 @@ watch(graphSubscription.error, () => {
 
     <Meta
       v-if="tab === Tab.Meta"
-      :graph="graphSubscription.data.value.graph"
+      :graph-uuid="graphSubscription.data.value.graph.uuid"
     />
 
     <Transition name="slide">

--- a/caster-editor/src/views/GraphDetailView.vue
+++ b/caster-editor/src/views/GraphDetailView.vue
@@ -3,13 +3,14 @@ import { storeToRefs } from "pinia";
 import { watch } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import Graph from "@/components/Graph.vue";
+import Meta from "@/components/Meta.vue";
 import Menu from "@/components/Menu.vue";
 import NodeEditor from "@/components/NodeEditor.vue";
-import { useInterfaceStore } from "@/stores/InterfaceStore";
+import { useInterfaceStore, Tab } from "@/stores/InterfaceStore";
 import { useGraphSubscription } from "@/graphql";
 import { ElMessage } from "element-plus";
 
-const { showNodeEditor, selectedNodeForEditorUuid } = storeToRefs(
+const { showNodeEditor, selectedNodeForEditorUuid, tab } = storeToRefs(
   useInterfaceStore(),
 );
 
@@ -39,6 +40,11 @@ watch(graphSubscription.error, () => {
     <Menu :graph="graphSubscription.data.value.graph" />
 
     <Graph :graph="graphSubscription.data.value.graph" />
+
+    <Meta
+      v-if="tab === Tab.Meta"
+      :graph="graphSubscription.data.value.graph"
+    />
 
     <Transition name="slide">
       <NodeEditor

--- a/caster-front/src/graphql.ts
+++ b/caster-front/src/graphql.ts
@@ -63,7 +63,7 @@ export type AddGraphInput = {
   /** Text about the graph which will be displayed at the start of a stream - only if this is set */
   startText?: InputMaybe<Scalars["String"]>;
   /** Manages the stream assignment for this graph */
-  streamAssignmentPolicy?: InputMaybe<Scalars["String"]>;
+  streamAssignmentPolicy?: InputMaybe<StreamAssignmentPolicy>;
   /** Allows to switch to a different template in the frontend with different connection flows or UI */
   templateName?: InputMaybe<GraphDetailTemplate>;
 };
@@ -362,10 +362,14 @@ export type Graph = {
   /** Name of the graph */
   name: Scalars["String"];
   nodes: Array<Node>;
+  /** If the graph is not public it will not be listed in the frontend, yet it is still accessible via URL */
+  publicVisible: Scalars["Boolean"];
   /** Will be used as a URL */
   slugName: Scalars["String"];
   /** Text about the graph which will be displayed at the start of a stream - only if this is set */
   startText: Scalars["String"];
+  /** Manages the stream assignment for this graph */
+  streamAssignmentPolicy: StreamAssignmentPolicy;
   /** Allows to switch to a different template in the frontend with different connection flows or UI */
   templateName: GraphDetailTemplate;
   uuid: Scalars["UUID"];
@@ -478,6 +482,7 @@ export type Mutation = {
   deleteScriptCell?: Maybe<Scalars["Void"]>;
   /** Update metadata of an :class:`~stream.models.AudioFile` via a UUID */
   updateAudioFile: AudioFile;
+  updateGraph: Graph;
   /**
    * Updates a given :class:`~story_graph.models.Node` which can be used
    * for renaming or moving it across the canvas.
@@ -554,6 +559,12 @@ export type MutationDeleteScriptCellArgs = {
 export type MutationUpdateAudioFileArgs = {
   updateAudioFile: UpdateAudioFile;
   uuid: Scalars["UUID"];
+};
+
+/** Mutations for Gencaster via GraphQL. */
+export type MutationUpdateGraphArgs = {
+  graphInput: UpdateGraphInput;
+  graphUuid: Scalars["UUID"];
 };
 
 /** Mutations for Gencaster via GraphQL. */
@@ -858,6 +869,13 @@ export type Stream = {
   uuid: Scalars["UUID"];
 };
 
+/** An enumeration. */
+export enum StreamAssignmentPolicy {
+  Deactivate = "DEACTIVATE",
+  OneGraphOneStream = "ONE_GRAPH_ONE_STREAM",
+  OneUserOneStream = "ONE_USER_ONE_STREAM",
+}
+
 export type StreamInfo = {
   stream: Stream;
   streamInstruction?: Maybe<StreamInstruction>;
@@ -1035,6 +1053,38 @@ export type UuidFilterLookup = {
 export type UpdateAudioFile = {
   description?: InputMaybe<Scalars["String"]>;
   name?: InputMaybe<Scalars["String"]>;
+};
+
+/**
+ * A collection of :class:`~Node` and :class:`~Edge`.
+ * This can be considered a score as well as a program as it
+ * has an entry point as a :class:`~Node` and can jump to any
+ * other :class:`~Node`, also allowing for recursive loops/cycles.
+ *
+ * Each node can be considered a little program on its own which can consist
+ * of multiple :class:`~ScriptCell` which can be coded in a variety of
+ * languages which can control the frontend and the audio (by e.g. speaking
+ * on the stream) or setting a background music.
+ *
+ * The story graph is a core concept and can be edited with a native editor.
+ */
+export type UpdateGraphInput = {
+  /** Text about the graph which can be accessed during a stream - only if this is set */
+  aboutText?: InputMaybe<Scalars["String"]>;
+  /** Will be used as a display name in the frontend */
+  displayName?: InputMaybe<Scalars["String"]>;
+  /** Text which will be displayed at the end of a stream */
+  endText?: InputMaybe<Scalars["String"]>;
+  /** Name of the graph */
+  name?: InputMaybe<Scalars["String"]>;
+  /** If the graph is not public it will not be listed in the frontend, yet it is still accessible via URL */
+  publicVisible?: InputMaybe<Scalars["Boolean"]>;
+  /** Text about the graph which will be displayed at the start of a stream - only if this is set */
+  startText?: InputMaybe<Scalars["String"]>;
+  /** Manages the stream assignment for this graph */
+  streamAssignmentPolicy?: InputMaybe<StreamAssignmentPolicy>;
+  /** Allows to switch to a different template in the frontend with different connection flows or UI */
+  templateName?: InputMaybe<GraphDetailTemplate>;
 };
 
 /**
@@ -1312,6 +1362,38 @@ export type NodeSubscription = {
   };
 };
 
+export type GraphMetaDataFragment = {
+  uuid: any;
+  templateName: GraphDetailTemplate;
+  startText: string;
+  slugName: string;
+  name: string;
+  endText: string;
+  displayName: string;
+  aboutText: string;
+  streamAssignmentPolicy: StreamAssignmentPolicy;
+  publicVisible: boolean;
+};
+
+export type GetGraphQueryVariables = Exact<{
+  graphUuid: Scalars["ID"];
+}>;
+
+export type GetGraphQuery = {
+  graph: {
+    uuid: any;
+    templateName: GraphDetailTemplate;
+    startText: string;
+    slugName: string;
+    name: string;
+    endText: string;
+    displayName: string;
+    aboutText: string;
+    streamAssignmentPolicy: StreamAssignmentPolicy;
+    publicVisible: boolean;
+  };
+};
+
 export type CreateGraphMutationVariables = Exact<{
   graphInput: AddGraphInput;
 }>;
@@ -1323,6 +1405,13 @@ export type CreateGraphMutation = {
     nodes: Array<{ name: string; uuid: any; isEntryNode: boolean }>;
   };
 };
+
+export type UpdateGraphMutationVariables = Exact<{
+  graphUuid: Scalars["UUID"];
+  graphUpdate: UpdateGraphInput;
+}>;
+
+export type UpdateGraphMutation = { updateGraph: { uuid: any } };
 
 export type StreamSubscriptionVariables = Exact<{
   graphUuid: Scalars["UUID"];
@@ -1674,6 +1763,20 @@ export const NodeDoorDetailFragmentDoc = gql`
     doorType
   }
 `;
+export const GraphMetaDataFragmentDoc = gql`
+  fragment GraphMetaData on Graph {
+    uuid
+    templateName
+    startText
+    slugName
+    name
+    endText
+    displayName
+    aboutText
+    streamAssignmentPolicy
+    publicVisible
+  }
+`;
 export const StreamInfoFragmentFragmentDoc = gql`
   fragment StreamInfoFragment on Stream {
     uuid
@@ -1981,6 +2084,20 @@ export function useNodeSubscription<R = NodeSubscription>(
     handler,
   );
 }
+export const GetGraphDocument = gql`
+  query GetGraph($graphUuid: ID!) {
+    graph(pk: $graphUuid) {
+      ...GraphMetaData
+    }
+  }
+  ${GraphMetaDataFragmentDoc}
+`;
+
+export function useGetGraphQuery(
+  options: Omit<Urql.UseQueryArgs<never, GetGraphQueryVariables>, "query"> = {},
+) {
+  return Urql.useQuery<GetGraphQuery>({ query: GetGraphDocument, ...options });
+}
 export const CreateGraphDocument = gql`
   mutation CreateGraph($graphInput: AddGraphInput!) {
     addGraph(graphInput: $graphInput) {
@@ -1998,6 +2115,19 @@ export const CreateGraphDocument = gql`
 export function useCreateGraphMutation() {
   return Urql.useMutation<CreateGraphMutation, CreateGraphMutationVariables>(
     CreateGraphDocument,
+  );
+}
+export const UpdateGraphDocument = gql`
+  mutation UpdateGraph($graphUuid: UUID!, $graphUpdate: UpdateGraphInput!) {
+    updateGraph(graphInput: $graphUpdate, graphUuid: $graphUuid) {
+      uuid
+    }
+  }
+`;
+
+export function useUpdateGraphMutation() {
+  return Urql.useMutation<UpdateGraphMutation, UpdateGraphMutationVariables>(
+    UpdateGraphDocument,
   );
 }
 export const StreamDocument = gql`


### PR DESCRIPTION
Most of the frontendimplementation is done. 
<img width="721" alt="Screenshot 2023-09-13 at 23 36 01" src="https://github.com/Gencaster/gencaster/assets/9806572/9ee85874-a32c-4c64-8568-9dc45a13ae9d">




Missing steps:

- [x] Update Graphql to offer Streamassignment options
- [x] Update Graphql on backend side to offer AboutText, etc
- [x] Add StreamingAssignment in Graphql request
- [x] Subscription for Meta Mutation
- [x] Validation? (maybe skipable for now, since we don't change the slug)
- [x] Submit to DB 

Could you help me with that @capital-G ?

The idea:
On `Meta` tab we load all the meta data of the graph. Once we made updates, we can submit those in a summarized mutation. There is no subscription to keep it simple.

Question:
I needed to add the AboutText, Displayname, ... to the `GraphDocument` Request. Do you think it's ok to extend it, or should we keep it clean and add a second request just for the Metadata?

I'm wondering, because in theory one could add a lot of images to one of these texts, which would in bloat the size of the `GraphDocument` request a lot. This could possibly lead to a bottleneck increasing the time of loading the editor. Since the data is only necessary if Metadata needs to be exchanged.

On the other hand, uploading incredibly big images to the `AboutText` would also put that load to the users. So maybe it's then just fair? :P