### PR TITLE
Fix node progression

### DIFF
--- a/caster-back/schema.gql
+++ b/caster-back/schema.gql
@@ -451,6 +451,16 @@ type InvalidPythonCode {
   errorCode: String!
 }
 
+"""Taken from ``logging`` module but omitting ``FATAL`` and ``WARN``."""
+enum LogLevel {
+  CRITICAL
+  ERROR
+  WARNING
+  INFO
+  DEBUG
+  NOTSET
+}
+
 type LoginError {
   errorMessage: String
 }
@@ -804,7 +814,7 @@ type StreamLog {
   streamPoint: StreamPoint
   stream: Stream
   origin: String
-  level: Int!
+  level: LogLevel!
   message: String!
   name: String
 }

--- a/caster-back/story_graph/engine.py
+++ b/caster-back/story_graph/engine.py
@@ -420,7 +420,7 @@ class Engine:
 
             # search for next node
             try:
-                await self.get_next_node()
+                self._current_node = await self.get_next_node()
             except GraphDeadEnd:
                 log.info(f"Ran into a dead end on {self.graph} on {self._current_node}")
                 return

--- a/caster-back/stream/types.py
+++ b/caster-back/stream/types.py
@@ -12,6 +12,8 @@ from strawberry_django.filters import FilterLookup
 
 from . import frontend_types, models
 
+LogLevelType = strawberry.enum(models.StreamLog.LogLevel)  # type: ignore
+
 
 @strawberry.django.filters.filter(models.StreamPoint, lookups=True)
 class StreamPointFilter:
@@ -152,6 +154,6 @@ class StreamLog:
     stream_point: StreamPoint
     stream: Stream
     origin: auto
-    level: auto
+    level: LogLevelType
     message: auto
     name: auto

--- a/caster-editor/src/components/StreamLogs.vue
+++ b/caster-editor/src/components/StreamLogs.vue
@@ -1,7 +1,8 @@
 <script lang="ts" setup>
 import type { StreamLogsSubscription } from "@/graphql";
-import { useStreamLogsSubscription, type StreamLog } from "@/graphql";
-import { ElTable, ElTableColumn } from "element-plus";
+import { useStreamLogsSubscription, type StreamLog, LogLevel } from "@/graphql";
+import { Scope } from "@sentry/vue";
+import { ElTable, ElTableColumn, ElTag } from "element-plus";
 import { ref, toRef, type Ref } from "vue";
 
 const props = defineProps<{
@@ -24,6 +25,35 @@ const { fetching } = useStreamLogsSubscription(
     logs.value.push(newInfo.streamLogs);
   },
 );
+
+const convertLogLevelType = (
+  level: string,
+): "success" | "info" | "warning" | "danger" | "" => {
+  switch (level) {
+    case LogLevel.Critical: {
+      return "danger";
+    }
+    case LogLevel.Error: {
+      return "danger";
+    }
+    case LogLevel.Warning: {
+      return "warning";
+    }
+    case LogLevel.Info: {
+      return "success";
+    }
+    case LogLevel.Debug: {
+      return "info";
+    }
+    default: {
+      return "";
+    }
+  }
+};
+
+const formatDate = (date: string): string => {
+  return new Date(date).toLocaleString("sv-SE");
+};
 </script>
 
 <template>
@@ -38,13 +68,23 @@ const { fetching } = useStreamLogsSubscription(
       <ElTableColumn
         prop="createdDate"
         label="Time"
-        width="300"
-      />
+        width="170"
+      >
+        <template #default="scope">
+          {{ formatDate(scope.row.createdDate) }}
+        </template>
+      </ElTableColumn>
       <ElTableColumn
         prop="level"
         label="Level"
         width="75"
-      />
+      >
+        <template #default="scope">
+          <ElTag :type="convertLogLevelType(scope.row.level)">
+            {{ scope.row.level }}
+          </ElTag>
+        </template>
+      </ElTableColumn>
       <ElTableColumn
         prop="message"
         label="Message"

--- a/caster-editor/src/graphql.ts
+++ b/caster-editor/src/graphql.ts
@@ -441,6 +441,16 @@ export type InvalidPythonCode = {
   errorType: Scalars["String"];
 };
 
+/** Taken from ``logging`` module but omitting ``FATAL`` and ``WARN``. */
+export enum LogLevel {
+  Critical = "CRITICAL",
+  Debug = "DEBUG",
+  Error = "ERROR",
+  Info = "INFO",
+  Notset = "NOTSET",
+  Warning = "WARNING",
+}
+
 export type LoginError = {
   errorMessage?: Maybe<Scalars["String"]>;
 };
@@ -900,7 +910,7 @@ export type StreamInstruction = {
 /** StreamLog(uuid, created_date, modified_date, stream_point, stream, origin, level, message, name) */
 export type StreamLog = {
   createdDate: Scalars["DateTime"];
-  level: Scalars["Int"];
+  level: LogLevel;
   message: Scalars["String"];
   name?: Maybe<Scalars["String"]>;
   origin?: Maybe<Scalars["String"]>;
@@ -1649,7 +1659,7 @@ export type StreamLogsSubscriptionVariables = Exact<{
 export type StreamLogsSubscription = {
   streamLogs: {
     createdDate: any;
-    level: number;
+    level: LogLevel;
     message: string;
     name?: string | null;
     uuid: any;

--- a/caster-front/src/graphql.ts
+++ b/caster-front/src/graphql.ts
@@ -441,6 +441,16 @@ export type InvalidPythonCode = {
   errorType: Scalars["String"];
 };
 
+/** Taken from ``logging`` module but omitting ``FATAL`` and ``WARN``. */
+export enum LogLevel {
+  Critical = "CRITICAL",
+  Debug = "DEBUG",
+  Error = "ERROR",
+  Info = "INFO",
+  Notset = "NOTSET",
+  Warning = "WARNING",
+}
+
 export type LoginError = {
   errorMessage?: Maybe<Scalars["String"]>;
 };
@@ -900,7 +910,7 @@ export type StreamInstruction = {
 /** StreamLog(uuid, created_date, modified_date, stream_point, stream, origin, level, message, name) */
 export type StreamLog = {
   createdDate: Scalars["DateTime"];
-  level: Scalars["Int"];
+  level: LogLevel;
   message: Scalars["String"];
   name?: Maybe<Scalars["String"]>;
   origin?: Maybe<Scalars["String"]>;
@@ -1649,7 +1659,7 @@ export type StreamLogsSubscriptionVariables = Exact<{
 export type StreamLogsSubscription = {
   streamLogs: {
     createdDate: any;
-    level: number;
+    level: LogLevel;
     message: string;
     name?: string | null;
     uuid: any;


### PR DESCRIPTION
* [x] Currently it is not possible to progress in the graph because the next node did not get updated. This PR fixes this bug, , see https://github.com/Gencaster/gencaster/commit/cd4a02fbc209ec13ad14763f79bfdea180cfc61d
* [x] Improved the UI of the streaming logs within the editor.
* [x] Added: If the active door has no out-going connections it will fall back to the default node door.

<img width="1204" alt="image" src="https://github.com/Gencaster/gencaster/assets/8267062/0194003f-6232-4d08-a8c7-e90da655091d">

`2==2` is always `True`, so the `other` door is taken, but as the door has no connections, the default node door is taken, see the logs

<img width="919" alt="image" src="https://github.com/Gencaster/gencaster/assets/8267062/79644d7a-4471-4e5d-bf22-8e775ff88cc4">

It is still possible to create an "early end" to a story by running into a dead end via the default node door.
If we want to really run into a dead end here it is possible by doing it this way.

<img width="1124" alt="image" src="https://github.com/Gencaster/gencaster/assets/8267062/c7c381d9-9db1-42fb-ae84-3fa4a5ad6d49">

with logs

<img width="813" alt="image" src="https://github.com/Gencaster/gencaster/assets/8267062/42927d4b-3de6-45c0-8825-1f716764a1ee">
